### PR TITLE
Fixed camera roll bug

### DIFF
--- a/sprout/components/CameraPage.tsx
+++ b/sprout/components/CameraPage.tsx
@@ -94,6 +94,8 @@ class CameraPage extends Component<Props> {
               result.base64,
               this.props.route.params.username
             );
+          } else {
+            return Promise.reject("cancelled");
           }
         })
         .then(plantInfo => {
@@ -105,6 +107,9 @@ class CameraPage extends Component<Props> {
             plantInfo: this.state.plantInfo,
             plantImage: this.state.plantImage,
           });
+        })
+        .catch(err => {
+          console.log(err);
         });
     });
   }


### PR DESCRIPTION
Added Promise.reject() to avoid navigating to PlantPage when leaving camera roll.